### PR TITLE
Don't install our own pip.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,5 @@
 FROM faucet/base:5.0.0
 
 RUN apk add --no-cache python3 && \
-    python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade pip setuptools && \
-    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-    rm -r /root/.cache
+    if [ ! -e /usr/bin/pip ]; then ln -s /usr/bin/pip3 /usr/bin/pip; fi && \
+    if [ ! -e /usr/bin/python ]; then ln -s /usr/bin/python3 /usr/bin/python; fi


### PR DESCRIPTION
Installing our own pip will lead to compatibility issues with underlying python:

```
Traceback (most recent call last):                                                                                                                                                                                                                                             
  File "/usr/bin/pip3", line 6, in <module>                                                                                                                                                                                                                                    
    from pip._internal import main                                                                                                                                                                                                                                             
  File "/usr/lib/python3.7/site-packages/pip/_internal/__init__.py", line 40, in <module>                                                                                                                                                                                      
    from pip._internal.cli.autocompletion import autocomplete                                                                                                                                                                                                                  
  File "/usr/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>                                                                                                                                                                             
    from pip._internal.cli.main_parser import create_main_parser                                                                                                                                                                                                               
  File "/usr/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py", line 11, in <module>                                                                                                                                                                               
    from pip._internal.commands import (                                                                                                                                                                                                                                       
  File "/usr/lib/python3.7/site-packages/pip/_internal/commands/__init__.py", line 6, in <module>                                                                                                                                                                              
    from pip._internal.commands.completion import CompletionCommand                                                                                                                                                                                                            
  File "/usr/lib/python3.7/site-packages/pip/_internal/commands/completion.py", line 6, in <module>                                                                                                                                                                            
    from pip._internal.cli.base_command import Command                                                                                                                                                                                                                         
  File "/usr/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 26, in <module>                                                                                                                                                                              
    from pip._internal.index import PackageFinder                                                                                                                                                                                                                              
ImportError: cannot import name 'PackageFinder' from 'pip._internal.index' (/usr/lib/python3.7/site-packages/pip/_internal/index/__init__.py) 
```